### PR TITLE
Fix the query params parser

### DIFF
--- a/source/assets/js/main.js
+++ b/source/assets/js/main.js
@@ -216,16 +216,18 @@ var QueryString = function () {
   var vars = query.split("&");
   for (var i=0;i<vars.length;i++) {
     var pair = vars[i].split("=");
+    var key = decodeURIComponent(pair[0]);
+    var val = decodeURIComponent(pair[1]);
       // If first entry with this name
-    if (typeof query_string[pair[0]] === "undefined") {
-      query_string[pair[0]] = pair[1];
+    if (typeof query_string[key] === "undefined") {
+      query_string[key] = val;
       // If second entry with this name
-    } else if (typeof query_string[pair[0]] === "string") {
-      var arr = [ query_string[pair[0]], pair[1] ];
-      query_string[pair[0]] = arr;
+    } else if (typeof query_string[key] === "string") {
+      var arr = [ query_string[key], val ];
+      query_string[key] = arr;
       // If third or later entry with this name
     } else {
-      query_string[pair[0]].push(pair[1]);
+      query_string[key].push(val);
     }
   } 
     return query_string;


### PR DESCRIPTION
Any URL with a query param shows `0` as score 😢 because the form is completed with an encoded string 😞 .

For example [yacir/collectionviewslantedlayout](http://clayallsopp.github.io/readme-score/?url=yacir%2Fcollectionviewslantedlayout) shows:

<img width="790" alt="capture d ecran 2018-01-17 a 04 58 22" src="https://user-images.githubusercontent.com/2587473/35025011-1426a304-fb43-11e7-8a2a-0d558ca59c0c.png">

This PR should fix it.
